### PR TITLE
Generate a website instead of a pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+_book/

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 main:
 	gitbook serve
+
+pdf:
+	mkdir -p dist
+	gitbook pdf . dist/desosa2017.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,2 @@
 main:
-	mkdir -p dist
-	gitbook pdf . dist/desosa2017.pdf
+	gitbook serve


### PR DESCRIPTION
Since we want to generate a website, and not a pdf, let's update the `make` command for this. Moreover, serving a gitbook and generating a website takes just 4 seconds, while the pdf version takes 155 seconds on my machine.

You can open http://localhost:4000/ to inspect the new book.