### PR TITLE
Fixed broken link to contributions chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ With these contributions the students had the ability to interact with the commu
 
 The students have written a collaborative chapter on some of the contributions made during the course. It can be found in the dedicated [contributions chapter][contrib-chapter].
 
-[contrib-chapter]: (contributions-chapter/chapter.md)
+[contrib-chapter]: contributions-chapter/chapter.md
 
 ## Feedback
 


### PR DESCRIPTION
Removed the '(' and ')' in the link to get it working again

**Broken link:**
```
The students have written a collaborative chapter on some of the contributions made during the course. It can be found in the dedicated [contributions chapter][contrib-chapter].

[contrib-chapter]: (contributions-chapter/chapter.md)
```

**Fixed link:**
```
The students have written a collaborative chapter on some of the contributions made during the course. It can be found in the dedicated [contributions chapter][contrib-chapter].

[contrib-chapter]: contributions-chapter/chapter.md
```