### PR TITLE
Fix invalid self-closing div tag

### DIFF
--- a/yarn/chapter.md
+++ b/yarn/chapter.md
@@ -374,7 +374,8 @@ When fixes for these bugs are merged into master, they are added to the version 
 After that, the changes are added to npm, and the CI builds and deploys the new version.
 
 #### Feature Flags
-<div id="feature-flags" />
+<div id="feature-flags"></div>
+
 As mentioned before, before adding a new feature, the RFC process is followed.
 When a new feature is being developed it is wrapped in a feature flag.
 This means that this feature is not used by default in the Yarn application, but can be enabled by enabling the corresponding flag.


### PR DESCRIPTION
This was breaking the next header in our chapter:
![image](https://cloud.githubusercontent.com/assets/5948271/25745513/82bd781a-319f-11e7-8b3c-81979a83a7f6.png)
