### PR TITLE
Add explicit mention of Yarn chapter authors and links to GitHub pages

### DIFF
--- a/yarn/chapter.md
+++ b/yarn/chapter.md
@@ -1,4 +1,6 @@
 # Yarn
+By [Tim van der Lippe](https://github.com/timvdlippe), [Chris Langhout](https://github.com/clanghout), [Gijs Weterings](https://github.com/gijsweterings) and [Chak Shun Yu](https://github.com/keraito).
+
 ![team-logo](images-yarn/teamyarnreadme.png)
 
 *Delft University of Technology*


### PR DESCRIPTION
When going through the other chapters and ours (Yarn), I discovered that we were the only chapter that did not explicitly specify our names, besides our beautiful team image 🎉 , and provide contact information. For the possible cases that someone wants to contact us, I have added a single line with our names and linked them to our respective GitHub pags.